### PR TITLE
 Support newer version of Keycloak

### DIFF
--- a/src/fastapi_oidc_auth/auth.py
+++ b/src/fastapi_oidc_auth/auth.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 
 
 class OpenIDConnect:
-    well_known_pattern = "{}/auth/realms/{}/.well-known/openid-configuration"
+    well_known_pattern = "{}/realms/{}/.well-known/openid-configuration"
 
     def __init__(
         self,


### PR DESCRIPTION
instead of 
`host = "http://localhost:8080"`

use
`host = "http://localhost:8080/auth"` for Keycloak 16
and
`host = "http://localhost:8080"` for newer version of Keycloak